### PR TITLE
Preload footstep assets

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/Animation/Notify/ALSAnimNotifyFootstep.cpp
+++ b/Source/ALSV4_CPP/Private/Character/Animation/Notify/ALSAnimNotifyFootstep.cpp
@@ -13,6 +13,27 @@
 #include "NiagaraFunctionLibrary.h"
 #include "NiagaraComponent.h"
 
+#include "Engine/AssetManager.h"
+
+void UALSAnimNotifyFootstep::PostLoad()
+{
+	Super::PostLoad();
+
+	// Preload footstep assets asynchronously
+	if (HitDataTable)
+	{
+		TArray<FALSHitFX*> HitFXRows;
+		HitDataTable->GetAllRows<FALSHitFX>(FString(), HitFXRows);
+
+		for (auto row : HitFXRows)
+		{
+			UAssetManager::Get().GetStreamableManager().RequestAsyncLoad(row->Sound.ToSoftObjectPath(), [](){});
+			UAssetManager::Get().GetStreamableManager().RequestAsyncLoad(row->NiagaraSystem.ToSoftObjectPath(), [](){});
+			UAssetManager::Get().GetStreamableManager().RequestAsyncLoad(row->DecalMaterial.ToSoftObjectPath(), [](){});
+		}
+	}
+}
+
 
 const FName NAME_Mask_FootstepSound(TEXT("Mask_FootstepSound"));
 
@@ -339,7 +360,8 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 				return;
 			}
 
-			if (bSpawnSound && HitFX->Sound.LoadSynchronous())
+			//if (bSpawnSound && HitFX->Sound.LoadSynchronous())
+			if (bSpawnSound && HitFX->Sound.IsValid())
 			{
 				UAudioComponent* SpawnedSound = nullptr;
 
@@ -372,7 +394,8 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 				}
 			}
 
-			if (bSpawnNiagara && HitFX->NiagaraSystem.LoadSynchronous())
+			//if (bSpawnNiagara && HitFX->NiagaraSystem.LoadSynchronous())
+			if (bSpawnNiagara && HitFX->NiagaraSystem.IsValid())
 			{
 				UNiagaraComponent* SpawnedParticle = nullptr;
 				const FVector Location = HitLocation + MeshOwner->GetTransform().TransformVector(
@@ -401,7 +424,8 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 				}
 			}
 
-			if (bSpawnDecal && HitFX->DecalMaterial.LoadSynchronous())
+			//if (bSpawnDecal && HitFX->DecalMaterial.LoadSynchronous())
+			if (bSpawnDecal && HitFX->DecalMaterial.IsValid())
 			{
 				const FVector Location = HitLocation + MeshOwner->GetTransform().TransformVector(
 					HitFX->DecalLocationOffset);

--- a/Source/ALSV4_CPP/Private/Character/Animation/Notify/ALSAnimNotifyFootstep.cpp
+++ b/Source/ALSV4_CPP/Private/Character/Animation/Notify/ALSAnimNotifyFootstep.cpp
@@ -24,12 +24,24 @@ void UALSAnimNotifyFootstep::PostLoad()
 	{
 		TArray<FALSHitFX*> HitFXRows;
 		HitDataTable->GetAllRows<FALSHitFX>(FString(), HitFXRows);
+		FStreamableManager& StreamableManager = UAssetManager::Get().GetStreamableManager();
 
-		for (auto row : HitFXRows)
+		for (FALSHitFX* Row : HitFXRows)
 		{
-			UAssetManager::Get().GetStreamableManager().RequestAsyncLoad(row->Sound.ToSoftObjectPath(), [](){});
-			UAssetManager::Get().GetStreamableManager().RequestAsyncLoad(row->NiagaraSystem.ToSoftObjectPath(), [](){});
-			UAssetManager::Get().GetStreamableManager().RequestAsyncLoad(row->DecalMaterial.ToSoftObjectPath(), [](){});
+			if (Row->Sound.IsPending())
+			{
+				StreamableManager.RequestAsyncLoad(Row->Sound.ToSoftObjectPath(), [](){});
+			}
+
+			if (Row->NiagaraSystem.IsPending())
+			{
+				StreamableManager.RequestAsyncLoad(Row->NiagaraSystem.ToSoftObjectPath(), [](){});
+			}
+
+			if (Row->DecalMaterial.IsPending())
+			{
+				StreamableManager.RequestAsyncLoad(Row->DecalMaterial.ToSoftObjectPath(), [](){});
+			}
 		}
 	}
 }
@@ -360,8 +372,7 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 				return;
 			}
 
-			//if (bSpawnSound && HitFX->Sound.LoadSynchronous())
-			if (bSpawnSound && HitFX->Sound.IsValid())
+			if (bSpawnSound && HitFX->Sound.LoadSynchronous())
 			{
 				UAudioComponent* SpawnedSound = nullptr;
 
@@ -394,8 +405,7 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 				}
 			}
 
-			//if (bSpawnNiagara && HitFX->NiagaraSystem.LoadSynchronous())
-			if (bSpawnNiagara && HitFX->NiagaraSystem.IsValid())
+			if (bSpawnNiagara && HitFX->NiagaraSystem.LoadSynchronous())
 			{
 				UNiagaraComponent* SpawnedParticle = nullptr;
 				const FVector Location = HitLocation + MeshOwner->GetTransform().TransformVector(
@@ -424,8 +434,8 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 				}
 			}
 
-			//if (bSpawnDecal && HitFX->DecalMaterial.LoadSynchronous())
-			if (bSpawnDecal && HitFX->DecalMaterial.IsValid())
+			if (bSpawnDecal && HitFX->DecalMaterial.LoadSynchronous())
+			//if (bSpawnDecal && HitFX->DecalMaterial.IsValid())
 			{
 				const FVector Location = HitLocation + MeshOwner->GetTransform().TransformVector(
 					HitFX->DecalLocationOffset);

--- a/Source/ALSV4_CPP/Public/Character/Animation/Notify/ALSAnimNotifyFootstep.h
+++ b/Source/ALSV4_CPP/Public/Character/Animation/Notify/ALSAnimNotifyFootstep.h
@@ -20,6 +20,8 @@ class ALSV4_CPP_API UALSAnimNotifyFootstep : public UAnimNotify
 {
 	GENERATED_BODY()
 
+	virtual void PostLoad() override;
+
 	virtual void Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, const FAnimNotifyEventReference& EventReference) override;
 
 	virtual FString GetNotifyName_Implementation() const override;


### PR DESCRIPTION
Footstep assets were hanging the game for a half second when being synchronously loaded while stepping on a new surface type. Preload the assets to fix the hang.